### PR TITLE
Fixed wrong library import and missing GPIO-Setup.

### DIFF
--- a/MoistureSensor.py
+++ b/MoistureSensor.py
@@ -1,7 +1,7 @@
 import ADC0834
-import Rpi.GPIO as GPIO
+import RPi.GPIO as GPIO # Hier war zuvor ein Typo beim Klassenbezeichner. Rpi mit kleinem p ist falsch. Die Klasse gibt es nicht. RPi hingegen schon.
 GPIO.setmode(GPIO.BCM)
-#adc = ADC0834()
+ADC0834.setup() # Setup-Funktion muss aufgerufen werden, da diese die GPIO-Pins konfiguriert.
 #value =adc.read( channel = 0 )
-sig = ADC0834.getResult(0)
+sig = ADC0834.getResult(0) # Sofern die GPIO-Pins konfiguriert sind, und alles korrekt verkabelt ist, sollte ein Wert abgefragt werden können.
 print("anliegende Spannung: %.2f" %(sig / 1023.0 * 3.3))


### PR DESCRIPTION
Ich habe zwei Dinge gefixt, die mir auffielen.
Einerseits war der Import der Bibliothek inkorrekt (Typo), zum Anderen wurde die setup()-Funktion nicht aufgerufen, welche die GPIO-Pins entsprechend konfiguriert.
Auf meinem Pi kann ich es nun anstandslos ausführen. Ob aber alles funktioniert, kann ich mangels entsprechender Sensoren nicht testen.